### PR TITLE
Adds typescript types 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 npm-debug\.log
+node_modules

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+declare module "react-native-parallax-header" {
+  import * as React from "react";
+  import * as ReactNative from "react-native";
+
+  interface RNParallaxHeaderProps {
+    renderNavBar?: () => React.ReactElement<any>;
+    renderContent: () => React.ReactElement<any>;
+    backgroundColor?: string;
+    backgroundImage?: ReactNative.ImageSourcePropType;
+    navbarColor?: string;
+    title?: string | React.ReactElement<any>;
+    titleStyle?: ReactNative.StyleProp<ReactNative.TextStyle>;
+    headerMaxHeight?: number;
+    headerMinHeight?: number;
+    scrollEventThrottle?: number;
+    extraScrollHeight?: number;
+    backgroundImageScale?: number;
+    contentContainerStyle?: ReactNative.StyleProp<ReactNative.ViewStyle>;
+    containerStyle?: ReactNative.StyleProp<ReactNative.ViewStyle>;
+    alwaysShowTitle?: boolean;
+    alwaysShowNavBar?: boolean;
+    statusBarColor?: string;
+  }
+  class ReactNativeParallaxHeader extends React.Component<RNParallaxHeaderProps> {}
+  export = ReactNativeParallaxHeader;
+}

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
   "bugs": {
     "url": "https://github.com/kyaroru/RNParallax/issues"
   },
-  "homepage": "https://github.com/kyaroru/RNParallax#readme"
+  "homepage": "https://github.com/kyaroru/RNParallax#readme",
+  "typings": "./index.d.ts"
 }


### PR DESCRIPTION
If you're interested in adding some validation for the types, I can help set that up but it would require adding `react`, `react-native`, and `typescript` as dev dependencies which I didn't want to do since there are none currently.  Basically, add those dependencies and then add an npm script with `npx tsc --noEmit ./index.d.ts`.