### PR TITLE
enable default onScroll behavior when caller passes in scrollViewProps.onScroll

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,6 +322,13 @@ class RNParallax extends Component {
       renderContent, scrollEventThrottle, scrollViewStyle, contentContainerStyle, innerContainerStyle, scrollViewProps,
     } = this.props;
     const { scrollY } = this.state;
+    const { onScroll } = scrollViewProps;
+
+    // remove scrollViewProps.onScroll in renderScrollViewProps so we can still get default scroll behavior
+    // if a caller passes in `onScroll` prop
+    const renderableScrollViewProps = Object.assign({}, scrollViewProps);
+    delete renderableScrollViewProps.onScroll;
+
     return (
       <Animated.ScrollView
         style={[styles.scrollView, scrollViewStyle]}
@@ -329,8 +336,9 @@ class RNParallax extends Component {
         scrollEventThrottle={scrollEventThrottle}
         onScroll={Animated.event(
           [{ nativeEvent: { contentOffset: { y: scrollY } } }],
+          { listener: onScroll }
         )}
-        {...scrollViewProps}
+        {...renderableScrollViewProps}
       >
         <View style={[{ marginTop: this.getHeaderMaxHeight() }, innerContainerStyle]}>
           {renderContent()}


### PR DESCRIPTION
Currently, if a caller passes in `scrollViewProps.onScroll`, that function overrides the default onScroll listener. This fix allows the default behavior to persist while also allowing `scrollViewProps.onScroll` to get passed in and called